### PR TITLE
add `DCLOGIN` uri scheme

### DIFF
--- a/uri-schemes.md
+++ b/uri-schemes.md
@@ -178,7 +178,7 @@ All advanced options are optional except for `v` and `p`, which are the only req
 | `ss`       | `smtp_security`           | SMTP security: "`ssl`", "`starttls`" or "`plain`"   | `ss=plain`            |
 | `sc`       | `smtp_certificate_checks` | SMTP certificate checks, see below for options      | `sc=3`                |
 
-#### `minVersion`
+#### format version
 
 Format version:
 Used for breaking new versions that add new **required** properties, basically deltachat checks for this and if it's newer than the version deltachat supports it prompts the user to update the app.
@@ -197,19 +197,18 @@ The version number only increases on incompatible changes (changes to required p
 
 - There is a maximum length of how much data fits in side of a qr code (depending on the error correction level 1273 chars to 2953 chars)
   - only use the short names for advanced properties
-  - If working with long domains/password/usernames in advanced options, **consider creating a configuration file at the server instead** using either [Autoconfigure](https://web.archive.org/web/20210402044801/https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration) or [Autodiscover](<https://technet.microsoft.com/library/bb124251(v=exchg.150).aspx>)
+  - If working with long domains/password/usernames in advanced options, **consider creating a configuration file at the server instead** using either [Autoconfigure](https://web.archive.org/web/20210402044801/https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration)
 - **Every value** (username & password too) **needs to be URI encoded**:
   - [`encodeURIComponent()` in JS](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent)
-- note that email username and password are in different order, than email: `username:password@host` vs. `username@host`
 
 #### Implementation hints
 
 implementations should be somewhat tolerant:
 
 - both `dclogin:` and `dclogin://` should work
-- only implement short names (not the full names they stand for)
-- have a test for usename+extention@host cases
-- if version is bigger than whats implemented tell the user to update
+- **only** implement short names (not the full names they stand for)
+- have a test for usename+extension@host cases
+- if version number is higher than what is implemented, tell the user to update
 
 ## **DCWEBRTC**
 

--- a/uri-schemes.md
+++ b/uri-schemes.md
@@ -217,7 +217,7 @@ The version number only increases on incompatible changes (changes to required p
 
 implementations should be somewhat tolerant:
 
-- both `dclogin:` and `dclogin://` should work
+- both `dclogin:` and `dclogin://` should work (though only `dclogin://` is technically correct)
 - **only** implement short names (not the full names they stand for)
 - have a test for usename+extension@host cases
 - if version number is higher than what is implemented, tell the user to update

--- a/uri-schemes.md
+++ b/uri-schemes.md
@@ -140,13 +140,13 @@ json object can have other properties too, but currently they are ignored by cor
 ### Syntax
 
 ```
-dclogin://user:password@host/?options
-dclogin://user:password@host?options
-dclogin:user:password@host/?options
+dclogin://user@host/?p=password&v=1[&options]
 # example: (email: me@example.com, password: securePassword)
-dclogin://me:securePassword@example.com?v=1
+dclogin://me@example.com?p=securePassword&v=1
+# example: (email: myself@example.com, password: url/Encoded\@passw@rd)
+dclogin://myself@example.com?p=url%2FEncoded%5C%40passw%40rd&v=1
 # example: (email: myself@example.com, password: 123456, insecure smtp at different server)
-dclogin://myself:123456@example.com?v=1&sh=mail.example.com&sc=3&ss=plain
+dclogin://myself@example.com?p=123456&v=1&sh=mail.example.com&sc=3&ss=plain
 ```
 
 #### Options `?options`
@@ -154,17 +154,19 @@ dclogin://myself:123456@example.com?v=1&sh=mail.example.com&sc=3&ss=plain
 Format: URL Query parameters also known as GET variables (`varname=value` behind the question mark, chained/delimited by `&`)
 
 The query parameters contain advanced options and a version parameter.
-All advanced options are optional except for `v`, which is the only required option at this point.
+All advanced options are optional except for `v` and `p`, which are the only required options at this point.
+(BTW: Later/Other versions in the future might specify a different authentication and thus `p` might become unnecessary in those formats.)
 
 | short name | stands for                | description                                         | example               |
 | ---------- | ------------------------- | --------------------------------------------------- | --------------------- |
 | `v`        | `version`                 | defines the format version, more explanation below  | `v=1`                 |
+| `p`        | `password`                | required in version 1, password of the account      |                       |
 | ---------- | ------------------------- | --------------------------------------------------- | ----------------      |
 | `ih`       | `imap_host`               | IMAP host                                           | `ih=imap.example.com` |
 | `ip`       | `imap_port`               | IMAP port                                           | `ip=993`              |
 | `iu`       | `imap_username`           | IMAP username                                       |                       |
 | `ipw`      | `imap_password`           | IMAP password                                       |                       |
-| `is`       | `imap_security`           | IMAP security: "`ssl`" or "`default`"               | `is=ssl`              |
+| `is`       | `imap_security`           | IMAP security: "`ssl`" or "`default`" or "`plain`"  | `is=ssl`              |
 | `ic`       | `imap_certificate_checks` | IMAP certificate checks, see below for options      | `ic=1`                |
 | ---------- | ------------------------- | --------------------------------------------------- | ----------------      |
 | `sh`       | `smtp_host`               | SMTP host                                           | `sh=mail.example.com` |

--- a/uri-schemes.md
+++ b/uri-schemes.md
@@ -192,7 +192,7 @@ The version number only increases on incompatible changes (changes to required p
 #### Important information for using the `DCLOGIN:` scheme
 
 - There is a maximum length of how much data fits in side of a qr code (depending on the error correction level 1273 chars to 2953 chars)
-  - make sure to use the short names for advanced properties
+  - only use the short names for advanced properties
   - If working with long domains/password/usernames in advanced options, **consider creating a configuration file at the server instead** using either [Autoconfigure](https://web.archive.org/web/20210402044801/https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration) or [Autodiscover](<https://technet.microsoft.com/library/bb124251(v=exchg.150).aspx>)
 - **Every value** (username & password too) **needs to be URI encoded**:
   - [`encodeURIComponent()` in JS](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent)

--- a/uri-schemes.md
+++ b/uri-schemes.md
@@ -140,9 +140,9 @@ json object can have other properties too, but currently they are ignored by cor
 ### Syntax
 
 ```
-DCLOGIN:minVersion/CredentialsJSON
+DCLOGIN:CredentialsJSON#minVersion
 # example:
-DCLOGIN:1/{"email":"me@example.com","password":""}
+DCLOGIN:{"email":"me@example.com","password":""}#1
 ```
 
 #### `minVersion`
@@ -153,6 +153,45 @@ Used for breaking new versions that add new **required** properties, basically d
 The version number only increases on incompatible changes (changes to required properties).
 
 It is outside the JSON, because we might want to use a more compact format than JSON in the future, like CBOR, BSON, msgpack or another binary format (see https://www.rfc-editor.org/rfc/rfc8949.html#section-appendix.e for some possible candidates).
+
+Another option for a posible future format could be URI based, like suggested here:
+`dclogin://password:name@example.com?smtpserver=loginname:password@smtp.example.com:1234&imapserver=loginname:password@imap.example.com:5678&smtpsecurity=ssltls&imapsecurity=ssltls&authmethod=auto&certchecks=auto` https://support.delta.chat/t/allow-users-to-generate-qr-codes-to-simplify-the-login-process/1406
+
+#### `CredentialsJSON`
+
+Version 1:
+```ts
+const enum CertificateChecks {
+  /**
+   * Same as `AcceptInvalidCertificates` unless overridden by
+   * `strict_tls` setting in provider database.
+   */
+  Automatic = 0,
+  Strict = 1,
+  AcceptInvalidCertificates = 3,
+}
+
+interface DC_LOGIN {
+  email: string;
+  password: string;
+  advanced_imap?: {
+    host?: string;
+    port?: number;
+    username?: string;
+    password?: string;
+    security?: "ssl" | "default";
+    certificate_checks: CertificateChecks;
+  };
+  advanced_smpt?: {
+    host?: string;
+    port?: number;
+    username?: string;
+    password?: string;
+    security?: "ssl" | "starttls" | "plain";
+    certificate_checks: CertificateChecks;
+  };
+}
+```
 
 ## **DCWEBRTC**
 

--- a/uri-schemes.md
+++ b/uri-schemes.md
@@ -140,6 +140,8 @@ json object can have other properties too, but currently they are ignored by cor
 ### Syntax
 
 ```
+dclogin:user@host?p=password&v=1[&options]
+dclogin:user@host/?p=password&v=1[&options]
 dclogin://user@host/?p=password&v=1[&options]
 # example: (email: me@example.com, password: securePassword)
 dclogin://me@example.com?p=securePassword&v=1

--- a/uri-schemes.md
+++ b/uri-schemes.md
@@ -139,9 +139,21 @@ json object can have other properties too, but currently they are ignored by cor
 
 ### Syntax
 
+The generic URI schema is:
+
+URI = scheme ":" ["//" authority] path ["?" query] ["#" fragment]
+authority = [userinfo "@"] host [":" port]
+
+For DCLOGIN this means:
+- *scheme* is always dclogin
+- There must be an *authority* section
+  - The *userinfo* part is required.
+- The *path* may be omitted or be a single `/`.
+- The fragment must be omitted.
+- The query parameters are described down below.
+
+Examples:
 ```
-dclogin:user@host?p=password&v=1[&options]
-dclogin:user@host/?p=password&v=1[&options]
 dclogin://user@host/?p=password&v=1[&options]
 # example: (email: me@example.com, password: securePassword)
 dclogin://me@example.com?p=securePassword&v=1

--- a/uri-schemes.md
+++ b/uri-schemes.md
@@ -156,7 +156,7 @@ Format: URL Query parameters also known as GET variables (`varname=value` behind
 The query parameters contain advanced options and a version parameter.
 All advanced options are optional except for `v`, which is the only required option at this point.
 
-| short name | full name                 | description                                         | example               |
+| short name | stands for                | description                                         | example               |
 | ---------- | ------------------------- | --------------------------------------------------- | --------------------- |
 | `v`        | `version`                 | defines the format version, more explanation below  | `v=1`                 |
 | ---------- | ------------------------- | --------------------------------------------------- | ----------------      |
@@ -203,10 +203,9 @@ The version number only increases on incompatible changes (changes to required p
 implementations should be somewhat tolerant:
 
 - both `dclogin:` and `dclogin://` should work
-- both short names and full names should be parsed for properties (though short names are preferred)
+- only implement short names (not the full names they stand for)
 - have a test for usename+extention@host cases
 - if version is bigger than whats implemented tell the user to update
-
 
 ## **DCWEBRTC**
 

--- a/uri-schemes.md
+++ b/uri-schemes.md
@@ -96,6 +96,8 @@ see the [mailadm](https://github.com/deltachat/mailadm) project for more details
 DCACCOUNT:https://example.org/new_email?t=1w_7wDjgjelxeX884x96v3
 ```
 
+You may want to use [`DCLOGIN`](#DCLOGIN) instead, if you want a qr code containing login information for a single account.
+
 #### The http endpoint needs the following api:
 
 ##### On Success
@@ -123,6 +125,34 @@ HTTP Status code: NOT 2XX, idealy the 4XX if it's user error and 5XX if it's the
 ```
 
 json object can have other properties too, but currently they are ignored by core.
+
+## **DCLOGIN** <a name="DCLOGIN"></a>
+
+|                          |                       |
+| ------------------------ | --------------------- |
+| Scheme                   | `DCLOGIN:`            |
+| Used for                 | Account setup         |
+| Related Terms\*          | Account Login QR code |
+| Available on             | draft                 |
+| Decoded by the core \*\* | draft                 |
+| Other apps using it      | none, only DeltaChat  |
+
+### Syntax
+
+```
+DCLOGIN:minVersion/CredentialsJSON
+# example:
+DCLOGIN:1/{"email":"me@example.com","password":""}
+```
+
+#### `minVersion`
+
+Format version:
+Used for breaking new versions that add new **required** properties, basically deltachat checks for this and if it's newer than the version deltachat supports it prompts the user to update the app.
+
+The version number only increases on incompatible changes (changes to required properties).
+
+It is outside the JSON, because we might want to use a more compact format than JSON in the future, like CBOR, BSON, msgpack or another binary format (see https://www.rfc-editor.org/rfc/rfc8949.html#section-appendix.e for some possible candidates).
 
 ## **DCWEBRTC**
 


### PR DESCRIPTION
What do you think about this specification?
If there are no issues I'll implement it in the next days.

### Implementation state

- core pr: https://github.com/deltachat/deltachat-core-rust/pull/3541
- desktop pr: [TODO]
- android pr: https://github.com/deltachat/deltachat-android/pull/2366
- ios pr: https://github.com/deltachat/deltachat-ios/pull/1702

#### Related Forum topics:

https://support.delta.chat/t/configure-email-account-via-qr-code/1805
https://support.delta.chat/t/configure-dc-account-through-qr-code/1164
https://support.delta.chat/t/allow-users-to-generate-qr-codes-to-simplify-the-login-process/1406
