### PR TITLE
remove outdated 'Out of scope' area

### DIFF
--- a/user-testing/README.md
+++ b/user-testing/README.md
@@ -74,11 +74,3 @@ hassle, don't worry about it and leave out those points.
 - [ ] Alice archives her Chat with Bob; she doesn't see it anymore
 - [ ] Bob writes her a mail, Alice receives it nonetheless, the chat is unarchived automatically
 
-### Out of scope
-
-Creating verified groups is out of scope for a community tester, until the
-Desktop client can join verified groups.
-
-Things which are already tested by automated tests, and don't have any UI,
-don't need testing.
-


### PR DESCRIPTION
- hint wrt verified-groups on desktop is hugely outdated
- the whole 'Out of scope' area seems questionable as it is not obvious to the tester which parts are already covered by automated tests. and even if things are tested eg. in core, UI may add bugs, so full-stack-tests are useful anyways.

in general, i am not sure if this testing checklist is used or known at all, cc eg. @gerryfrancis 


closes #52 